### PR TITLE
Use markdown backticks for regex patterns to fix MDX rendering

### DIFF
--- a/addons/br-nfe-v4.mdx
+++ b/addons/br-nfe-v4.mdx
@@ -70,7 +70,7 @@ remaining digits identify the specific type of operation.
 
 <Accordion title="br-nfe-cfop">
 
-Pattern: <code>^[1-7]\d{3}$</code>
+Pattern: `^[1-7]\d{3}$`
 </Accordion>
 ### Fiscal Incentive Indicator	
 

--- a/addons/br-nfse-v1.mdx
+++ b/addons/br-nfse-v1.mdx
@@ -15,7 +15,7 @@ List of codes from the IBGE (Brazilian Institute of Geography and Statistics):
 
 <Accordion title="br-nfse-cnae">
 
-Pattern: <code>^\d{2}[\s\.\-\/]?\d{2}[\s\.\-\/]?\d[\s\.\-\/]?\d{2}$</code>
+Pattern: `^\d{2}[\s\.\-\/]?\d{2}[\s\.\-\/]?\d[\s\.\-\/]?\d{2}$`
 </Accordion>
 ### NBS code	
 
@@ -31,7 +31,7 @@ Official list of codes from the MDIC:
 
 <Accordion title="br-nfse-nbs">
 
-Pattern: <code>^\d[\.\s]?\d{4}[\.\s]?\d{2}[\.\s]?\d{2}$</code>
+Pattern: `^\d[\.\s]?\d{4}[\.\s]?\d{2}[\.\s]?\d{2}$`
 </Accordion>
 ### Fiscal Incentive	
 
@@ -117,7 +117,7 @@ List of possible values:
 
 <Accordion title="br-nfse-operation">
 
-Pattern: <code>^\d{6}$</code>
+Pattern: `^\d{6}$`
 </Accordion>
 ### Tax Status Code (CST)	
 
@@ -132,7 +132,7 @@ List of possible values:
 
 <Accordion title="br-nfse-tax-status">
 
-Pattern: <code>^\d{3}$</code>
+Pattern: `^\d{3}$`
 </Accordion>
 ### Tax Classification Code	
 
@@ -147,5 +147,5 @@ List of possible values:
 
 <Accordion title="br-nfse-tax-class">
 
-Pattern: <code>^\d{6}$</code>
+Pattern: `^\d{6}$`
 </Accordion>

--- a/addons/co-dian-v2.mdx
+++ b/addons/co-dian-v2.mdx
@@ -231,7 +231,7 @@ the supplier and customer:
 
 <Accordion title="co-dian-municipality">
 
-Pattern: <code>^\d{5}$</code>
+Pattern: `^\d{5}$`
 </Accordion>
 ### Credit Code	
 

--- a/addons/it-ticket-v1.mdx
+++ b/addons/it-ticket-v1.mdx
@@ -57,7 +57,7 @@ It is used to identify the customer in the lottery system provided by the Agenzi
 
 <Accordion title="it-ticket-lottery">
 
-Pattern: <code>^[A-Z0-9]{8}$</code>
+Pattern: `^[A-Z0-9]{8}$`
 </Accordion>
 ### AdE Line Reference	
 

--- a/addons/mx-cfdi-v4.mdx
+++ b/addons/mx-cfdi-v4.mdx
@@ -34,7 +34,7 @@ Post code of where the invoice was issued. In CFDI, this translates to the 'Luga
 
 <Accordion title="mx-cfdi-issue-place">
 
-Pattern: <code>^[0-9]{5}$</code>
+Pattern: `^[0-9]{5}$`
 </Accordion>
 ### Tax Type	
 
@@ -205,5 +205,5 @@ Specific month or month range for the global invoice.
 
 <Accordion title="mx-cfdi-global-year">
 
-Pattern: <code>\d{4}</code>
+Pattern: `\d{4}`
 </Accordion>

--- a/catalogues/iso.mdx
+++ b/catalogues/iso.mdx
@@ -14,5 +14,5 @@ The ISO 6523 set of identifies is used by the EN16931 standard for electronic in
 
 <Accordion title="iso-scheme-id">
 
-Pattern: <code>^\d{4}$</code>
+Pattern: `^\d{4}$`
 </Accordion>

--- a/cmd/generate/addons.go
+++ b/cmd/generate/addons.go
@@ -26,6 +26,7 @@ func newAddonGenerator(a *tax.AddonDef) *addonGenerator {
 		"t": func(s i18n.String) string {
 			return s.String()
 		},
+		"bt":       backtick,
 		"joinKeys": joinKeys,
 		"codeMap":  codeMap,
 	})

--- a/cmd/generate/catalogue.go
+++ b/cmd/generate/catalogue.go
@@ -26,6 +26,7 @@ func newCatalogueGenerator(d *tax.CatalogueDef) *catalogueGenerator {
 		"t": func(s i18n.String) string {
 			return s.String()
 		},
+		"bt":       backtick,
 		"joinKeys": joinKeys,
 		"codeMap":  codeMap,
 	})

--- a/cmd/generate/generator.go
+++ b/cmd/generate/generator.go
@@ -136,7 +136,7 @@ func (g *generator) extension(kd *cbc.Definition) error {
 
 		{{- if .Pattern }}
 
-		Pattern: <code>{{ .Pattern }}</code>
+		Pattern: {{bt}}{{ .Pattern }}{{bt}}
 		{{- end }}
 
 

--- a/cmd/generate/regimes.go
+++ b/cmd/generate/regimes.go
@@ -46,8 +46,9 @@ func newRegimeGenerator(r *tax.RegimeDef) *regimeGenerator {
 		"extension":     g.taxRateExtension,
 		"extensionKeys": g.getExtensionKeys,
 		"rateRows":      g.getRateRows,
-		"joinKeys":      joinKeys,
-		"codeMap":       codeMap,
+		"bt":       backtick,
+		"joinKeys": joinKeys,
+		"codeMap":  codeMap,
 	})
 	return g
 }

--- a/cmd/generate/utils.go
+++ b/cmd/generate/utils.go
@@ -7,6 +7,12 @@ import (
 	"github.com/invopop/gobl/cbc"
 )
 
+// backtick returns a literal backtick character for use in templates
+// where the surrounding Go raw string literal prevents using backticks directly.
+func backtick() string {
+	return "`"
+}
+
 func joinKeys(keys []cbc.Key) string {
 	var s []string
 	for _, k := range keys {

--- a/regimes/br.mdx
+++ b/regimes/br.mdx
@@ -64,5 +64,5 @@ Statistics).
 
 <Accordion title="br-ibge-municipality">
 
-Pattern: <code>^\d{7}$</code>
+Pattern: `^\d{7}$`
 </Accordion>


### PR DESCRIPTION
## Summary

Regex patterns inside `<code>` tags were rendered incorrectly because MDX interprets curly braces as JSX expressions and backslashes as escape sequences.

**Before:** `^\d2[\s.-/]?\d2[\s.-/]?\d[\s.-/]?\d2$`
**After:** `^\d{2}[\s\.\-\/]?\d{2}[\s\.\-\/]?\d[\s\.\-\/]?\d{2}$`

The fix replaces `<code>` tags with markdown backticks for pattern values, which MDX treats as literal text, preserving the regex as-is. A `bt` (backtick) template helper is added since the Go templates use raw string literals where backticks can't appear directly.

Fixes #38 (transferred from invopop/gobl#781)

## Test plan
- [x] `go build ./cmd/generate/` succeeds
- [x] `go run ./cmd/generate/` regenerates all `.mdx` files
- [x] Verified locally with `mintlify dev` that patterns render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)