### PR TITLE
Refine correction definition for invoice generation

### DIFF
--- a/cmd/generate/generator.go
+++ b/cmd/generate/generator.go
@@ -52,8 +52,6 @@ func (g *generator) preceding(defs tax.CorrectionSet) error {
 
 		## Correction Definitions
 
-		Auto-generation of corrective invoices is supported.
-
 		{{- if .ReasonRequired }}
 
 		A reason is required in the <code>reason</code> field

--- a/cmd/generate/generator.go
+++ b/cmd/generate/generator.go
@@ -52,8 +52,7 @@ func (g *generator) preceding(defs tax.CorrectionSet) error {
 
 		## Correction Definitions
 
-		Auto-generation of corrective invoices or credit and debit notes is
-		supported.
+		Auto-generation of corrective invoices is supported.
 
 		{{- if .ReasonRequired }}
 


### PR DESCRIPTION
The correction definitions description hardcodes support for invoice types (credit notes and debit notes), but this is not always true. I'm removing the description as it will simply restate the title without adding new information.

<img width="1320" height="644" alt="image" src="https://github.com/user-attachments/assets/9ae7ba63-1beb-4f09-a953-a12ee5267630" />
