### PR TITLE
Scope scenarios per category and surface filters in a table

### DIFF
--- a/addons/ar-arca-v4.mdx
+++ b/addons/ar-arca-v4.mdx
@@ -317,6 +317,10 @@ The VAT status is validated against the document type:
 
 ## Validation Rules
 
+Validation rules check each struct against a set of assertions and report any
+failures with a unique code and message.
+[Read more about validation](/overview/validation).
+
 <AccordionGroup>
 <Accordion title="bill.Invoice">
 

--- a/addons/br-nfe-v4.mdx
+++ b/addons/br-nfe-v4.mdx
@@ -6,26 +6,19 @@ Key: `br-nfe-v4`
 
 ## Scenarios
 
-### bill/invoice
+Scenarios attach notes and extensions to a document when its filters match.
+[Read more about scenarios](/overview/scenarios).
 
-<Accordion title="standard, credit-note, debit-note">
+<AccordionGroup>
+<Accordion title="bill/invoice">
 
-**Filters:**
-- **Types:** `standard`, `credit-note`, `debit-note`
+| Tags | Type | Output |
+| --- | --- | --- |
+| - | `standard`<br />`credit-note`<br />`debit-note` | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"ext": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"br-nfe-model": "55"<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
+| `simplified` | `standard`<br />`credit-note`<br />`debit-note` | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"ext": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"br-nfe-model": "65"<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
 
-**Output:**
-- **Extensions:** `br-nfe-model:55`
 </Accordion>
-
-<Accordion title="standard, credit-note, debit-note, #simplified">
-
-**Filters:**
-- **Types:** `standard`, `credit-note`, `debit-note`
-- **Tags:** `simplified`
-
-**Output:**
-- **Extensions:** `br-nfe-model:65`
-</Accordion>
+</AccordionGroup>
 
 ## Extensions
 ### Fiscal Document Model Code
@@ -135,6 +128,10 @@ Indicates a special tax regime that a party is subject to.
 </Accordion>
 
 ## Validation Rules
+
+Validation rules check each struct against a set of assertions and report any
+failures with a unique code and message.
+[Read more about validation](/overview/validation).
 
 <AccordionGroup>
 <Accordion title="bill.Invoice">

--- a/addons/br-nfse-v1.mdx
+++ b/addons/br-nfse-v1.mdx
@@ -152,6 +152,10 @@ Pattern: `^\d{6}$`
 
 ## Validation Rules
 
+Validation rules check each struct against a set of assertions and report any
+failures with a unique code and message.
+[Read more about validation](/overview/validation).
+
 <AccordionGroup>
 <Accordion title="bill.Invoice">
 

--- a/addons/co-dian-v2.mdx
+++ b/addons/co-dian-v2.mdx
@@ -336,6 +336,10 @@ For example:
 
 ## Validation Rules
 
+Validation rules check each struct against a set of assertions and report any
+failures with a unique code and message.
+[Read more about validation](/overview/validation).
+
 <AccordionGroup>
 <Accordion title="bill.Invoice">
 

--- a/addons/de-xrechnung-v3.mdx
+++ b/addons/de-xrechnung-v3.mdx
@@ -13,6 +13,10 @@ For more information on XRechnung, visit [www.xrechnung.de](https://www.xrechnun
 
 ## Validation Rules
 
+Validation rules check each struct against a set of assertions and report any
+failures with a unique code and message.
+[Read more about validation](/overview/validation).
+
 <AccordionGroup>
 <Accordion title="bill.Invoice">
 

--- a/addons/es-facturae-v3.mdx
+++ b/addons/es-facturae-v3.mdx
@@ -17,91 +17,26 @@ options. See the [Extensions](#extensions) section for possible values.
 
 ## Scenarios
 
-### bill/invoice
+Scenarios attach notes and extensions to a document when its filters match.
+[Read more about scenarios](/overview/scenarios).
 
-<Accordion title="standard, corrective, credit-note, debit-note">
+<AccordionGroup>
+<Accordion title="bill/invoice">
 
-**Filters:**
-- **Types:** `standard`, `corrective`, `credit-note`, `debit-note`
+| Tags | Type | Output |
+| --- | --- | --- |
+| - | `standard`<br />`corrective`<br />`credit-note`<br />`debit-note` | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"ext": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"es-facturae-doc-type": "FC"<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
+| `simplified` | - | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"ext": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"es-facturae-doc-type": "FA"<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
+| `self-billed` | - | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"ext": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"es-facturae-doc-type": "AF"<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
+| - | `standard` | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"ext": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"es-facturae-invoice-class": "OO"<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
+| - | `corrective`<br />`credit-note`<br />`debit-note` | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"ext": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"es-facturae-invoice-class": "OR"<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
+| `summary` | - | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"ext": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"es-facturae-invoice-class": "OC"<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
+| `copy` | `standard` | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"ext": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"es-facturae-invoice-class": "CO"<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
+| `copy` | `corrective` | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"ext": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"es-facturae-invoice-class": "CR"<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
+| `copy`<br />`summary` | `standard` | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"ext": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"es-facturae-invoice-class": "CC"<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
 
-**Output:**
-- **Extensions:** `es-facturae-doc-type:FC`
 </Accordion>
-
-<Accordion title="#simplified">
-
-**Filters:**
-- **Tags:** `simplified`
-
-**Output:**
-- **Extensions:** `es-facturae-doc-type:FA`
-</Accordion>
-
-<Accordion title="#self-billed">
-
-**Filters:**
-- **Tags:** `self-billed`
-
-**Output:**
-- **Extensions:** `es-facturae-doc-type:AF`
-</Accordion>
-
-<Accordion title="standard">
-
-**Filters:**
-- **Types:** `standard`
-
-**Output:**
-- **Extensions:** `es-facturae-invoice-class:OO`
-</Accordion>
-
-<Accordion title="corrective, credit-note, debit-note">
-
-**Filters:**
-- **Types:** `corrective`, `credit-note`, `debit-note`
-
-**Output:**
-- **Extensions:** `es-facturae-invoice-class:OR`
-</Accordion>
-
-<Accordion title="#summary">
-
-**Filters:**
-- **Tags:** `summary`
-
-**Output:**
-- **Extensions:** `es-facturae-invoice-class:OC`
-</Accordion>
-
-<Accordion title="standard, #copy">
-
-**Filters:**
-- **Types:** `standard`
-- **Tags:** `copy`
-
-**Output:**
-- **Extensions:** `es-facturae-invoice-class:CO`
-</Accordion>
-
-<Accordion title="corrective, #copy">
-
-**Filters:**
-- **Types:** `corrective`
-- **Tags:** `copy`
-
-**Output:**
-- **Extensions:** `es-facturae-invoice-class:CR`
-</Accordion>
-
-<Accordion title="standard, #copy, #summary">
-
-**Filters:**
-- **Types:** `standard`
-- **Tags:** `copy`, `summary`
-
-**Output:**
-- **Extensions:** `es-facturae-invoice-class:CC`
-</Accordion>
+</AccordionGroup>
 
 ## Extensions
 ### FacturaE: Document Type
@@ -160,6 +95,10 @@ FacturaE requires a specific and single code that explains why the previous invo
 </Accordion>
 
 ## Validation Rules
+
+Validation rules check each struct against a set of assertions and report any
+failures with a unique code and message.
+[Read more about validation](/overview/validation).
 
 <AccordionGroup>
 <Accordion title="bill.Invoice">

--- a/addons/es-sii-v1.mdx
+++ b/addons/es-sii-v1.mdx
@@ -20,46 +20,21 @@ options. See the [Extensions](#extensions) section for possible values.
 
 ## Scenarios
 
-### bill/invoice
+Scenarios attach notes and extensions to a document when its filters match.
+[Read more about scenarios](/overview/scenarios).
 
-<Accordion title="Standard Invoice">
+<AccordionGroup>
+<Accordion title="bill/invoice">
 
-**Filters:**
-- **Types:** `standard`
+| Tags | Type | Output |
+| --- | --- | --- |
+| - | `standard` | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"ext": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"es-sii-doc-type": "F1"<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
+| `simplified` | `standard` | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"ext": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"es-sii-doc-type": "F2"<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
+| `replacement` | `standard` | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"ext": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"es-sii-doc-type": "F3"<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
+| `simplified` | `corrective`<br />`credit-note`<br />`debit-note` | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"ext": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"es-sii-doc-type": "R5"<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
 
-**Output:**
-- **Extensions:** `es-sii-doc-type:F1`
 </Accordion>
-
-<Accordion title="Simplified Invoice">
-
-**Filters:**
-- **Types:** `standard`
-- **Tags:** `simplified`
-
-**Output:**
-- **Extensions:** `es-sii-doc-type:F2`
-</Accordion>
-
-<Accordion title="Replacement Invoice">
-
-**Filters:**
-- **Types:** `standard`
-- **Tags:** `replacement`
-
-**Output:**
-- **Extensions:** `es-sii-doc-type:F3`
-</Accordion>
-
-<Accordion title="Simplified Corrective Invoice">
-
-**Filters:**
-- **Types:** `corrective`, `credit-note`, `debit-note`
-- **Tags:** `simplified`
-
-**Output:**
-- **Extensions:** `es-sii-doc-type:R5`
-</Accordion>
+</AccordionGroup>
 
 ## Extensions
 ### Invoice Type
@@ -336,6 +311,10 @@ Doesn't map directly to any field. Used internally to structure the breakdown da
 </Accordion>
 
 ## Validation Rules
+
+Validation rules check each struct against a set of assertions and report any
+failures with a unique code and message.
+[Read more about validation](/overview/validation).
 
 <AccordionGroup>
 <Accordion title="bill.Invoice">

--- a/addons/es-tbai-v1.mdx
+++ b/addons/es-tbai-v1.mdx
@@ -102,6 +102,10 @@ data.
 
 ## Validation Rules
 
+Validation rules check each struct against a set of assertions and report any
+failures with a unique code and message.
+[Read more about validation](/overview/validation).
+
 <AccordionGroup>
 <Accordion title="bill.Invoice">
 

--- a/addons/es-verifactu-v1.mdx
+++ b/addons/es-verifactu-v1.mdx
@@ -20,46 +20,21 @@ options. See the [Extensions](#extensions) section for possible values.
 
 ## Scenarios
 
-### bill/invoice
+Scenarios attach notes and extensions to a document when its filters match.
+[Read more about scenarios](/overview/scenarios).
 
-<Accordion title="Standard Invoice">
+<AccordionGroup>
+<Accordion title="bill/invoice">
 
-**Filters:**
-- **Types:** `standard`
+| Tags | Type | Output |
+| --- | --- | --- |
+| - | `standard` | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"ext": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"es-verifactu-doc-type": "F1"<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
+| `simplified` | `standard` | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"ext": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"es-verifactu-doc-type": "F2"<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
+| `replacement` | `standard` | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"ext": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"es-verifactu-doc-type": "F3"<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
+| `simplified` | `corrective`<br />`credit-note`<br />`debit-note` | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"ext": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"es-verifactu-doc-type": "R5"<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
 
-**Output:**
-- **Extensions:** `es-verifactu-doc-type:F1`
 </Accordion>
-
-<Accordion title="Simplified Invoice">
-
-**Filters:**
-- **Types:** `standard`
-- **Tags:** `simplified`
-
-**Output:**
-- **Extensions:** `es-verifactu-doc-type:F2`
-</Accordion>
-
-<Accordion title="Replacement Invoice">
-
-**Filters:**
-- **Types:** `standard`
-- **Tags:** `replacement`
-
-**Output:**
-- **Extensions:** `es-verifactu-doc-type:F3`
-</Accordion>
-
-<Accordion title="Simplified Corrective Invoice">
-
-**Filters:**
-- **Types:** `corrective`, `credit-note`, `debit-note`
-- **Tags:** `simplified`
-
-**Output:**
-- **Extensions:** `es-verifactu-doc-type:R5`
-</Accordion>
+</AccordionGroup>
 
 ## Extensions
 ### Invoice Type Code
@@ -314,6 +289,10 @@ extension will be set to `T`.
 </Accordion>
 
 ## Validation Rules
+
+Validation rules check each struct against a set of assertions and report any
+failures with a unique code and message.
+[Read more about validation](/overview/validation).
 
 <AccordionGroup>
 <Accordion title="bill.Invoice">

--- a/addons/eu-en16931-v2017.mdx
+++ b/addons/eu-en16931-v2017.mdx
@@ -48,114 +48,34 @@ exemption note covering it.
 
 ## Scenarios
 
-### bill/invoice
+Scenarios attach notes and extensions to a document when its filters match.
+[Read more about scenarios](/overview/scenarios).
 
-<Accordion title="standard">
+<AccordionGroup>
+<Accordion title="bill/invoice">
 
-**Filters:**
-- **Types:** `standard`
+| Tags | Type | Output |
+| --- | --- | --- |
+| - | `standard` | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"ext": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"untdid-document-type": "380"<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
+| - | `credit-note` | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"ext": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"untdid-document-type": "381"<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
+| - | `debit-note` | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"ext": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"untdid-document-type": "383"<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
+| - | `corrective` | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"ext": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"untdid-document-type": "384"<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
+| - | `proforma` | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"ext": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"untdid-document-type": "325"<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
+| `partial` | `standard` | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"ext": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"untdid-document-type": "326"<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
+| `self-billed` | `standard` | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"ext": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"untdid-document-type": "389"<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
+| `self-billed` | `credit-note` | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"ext": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"untdid-document-type": "261"<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
+| `prepayment` | `standard` | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"ext": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"untdid-document-type": "386"<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
+| `factoring` | `standard` | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"ext": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"untdid-document-type": "393"<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
+| `factoring` | `credit-note` | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"ext": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"untdid-document-type": "396"<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
 
-**Output:**
-- **Extensions:** `untdid-document-type:380`
 </Accordion>
-
-<Accordion title="credit-note">
-
-**Filters:**
-- **Types:** `credit-note`
-
-**Output:**
-- **Extensions:** `untdid-document-type:381`
-</Accordion>
-
-<Accordion title="debit-note">
-
-**Filters:**
-- **Types:** `debit-note`
-
-**Output:**
-- **Extensions:** `untdid-document-type:383`
-</Accordion>
-
-<Accordion title="corrective">
-
-**Filters:**
-- **Types:** `corrective`
-
-**Output:**
-- **Extensions:** `untdid-document-type:384`
-</Accordion>
-
-<Accordion title="proforma">
-
-**Filters:**
-- **Types:** `proforma`
-
-**Output:**
-- **Extensions:** `untdid-document-type:325`
-</Accordion>
-
-<Accordion title="standard, #partial">
-
-**Filters:**
-- **Types:** `standard`
-- **Tags:** `partial`
-
-**Output:**
-- **Extensions:** `untdid-document-type:326`
-</Accordion>
-
-<Accordion title="standard, #self-billed">
-
-**Filters:**
-- **Types:** `standard`
-- **Tags:** `self-billed`
-
-**Output:**
-- **Extensions:** `untdid-document-type:389`
-</Accordion>
-
-<Accordion title="credit-note, #self-billed">
-
-**Filters:**
-- **Types:** `credit-note`
-- **Tags:** `self-billed`
-
-**Output:**
-- **Extensions:** `untdid-document-type:261`
-</Accordion>
-
-<Accordion title="standard, #prepayment">
-
-**Filters:**
-- **Types:** `standard`
-- **Tags:** `prepayment`
-
-**Output:**
-- **Extensions:** `untdid-document-type:386`
-</Accordion>
-
-<Accordion title="standard, #factoring">
-
-**Filters:**
-- **Types:** `standard`
-- **Tags:** `factoring`
-
-**Output:**
-- **Extensions:** `untdid-document-type:393`
-</Accordion>
-
-<Accordion title="credit-note, #factoring">
-
-**Filters:**
-- **Types:** `credit-note`
-- **Tags:** `factoring`
-
-**Output:**
-- **Extensions:** `untdid-document-type:396`
-</Accordion>
+</AccordionGroup>
 
 ## Validation Rules
+
+Validation rules check each struct against a set of assertions and report any
+failures with a unique code and message.
+[Read more about validation](/overview/validation).
 
 <AccordionGroup>
 <Accordion title="bill.Invoice">

--- a/addons/fr-choruspro-v1.mdx
+++ b/addons/fr-choruspro-v1.mdx
@@ -70,6 +70,10 @@ replaced by GOBL during normalization.
 
 ## Validation Rules
 
+Validation rules check each struct against a set of assertions and report any
+failures with a unique code and message.
+[Read more about validation](/overview/validation).
+
 <AccordionGroup>
 <Accordion title="bill.Invoice">
 

--- a/addons/fr-ctc-flow2-v1.mdx
+++ b/addons/fr-ctc-flow2-v1.mdx
@@ -59,6 +59,10 @@ The numeric suffix indicates the payment type (1=deposit, 2=already paid,
 
 ## Validation Rules
 
+Validation rules check each struct against a set of assertions and report any
+failures with a unique code and message.
+[Read more about validation](/overview/validation).
+
 <AccordionGroup>
 <Accordion title="bill.Invoice">
 

--- a/addons/gr-mydata-v1.mdx
+++ b/addons/gr-mydata-v1.mdx
@@ -14,145 +14,31 @@ generate the myDATA XML reporting files.
 
 ## Scenarios
 
-### bill/invoice
+Scenarios attach notes and extensions to a document when its filters match.
+[Read more about scenarios](/overview/scenarios).
 
-<Accordion title="standard">
+<AccordionGroup>
+<Accordion title="bill/invoice">
 
-**Filters:**
-- **Types:** `standard`
+| Tags | Type | Output |
+| --- | --- | --- |
+| - | `standard` | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"ext": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"gr-mydata-invoice-type": "2.1"<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
+| `goods` | `standard` | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"ext": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"gr-mydata-invoice-type": "1.1"<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
+| `goods`<br />`export` | `standard` | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"ext": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"gr-mydata-invoice-type": "1.3"<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
+| `goods`<br />`export`<br />`eu` | `standard` | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"ext": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"gr-mydata-invoice-type": "1.2"<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
+| `goods`<br />`self-billed` | `standard` | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"ext": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"gr-mydata-invoice-type": "1.4"<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
+| `services` | `standard` | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"ext": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"gr-mydata-invoice-type": "2.1"<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
+| `services`<br />`export` | `standard` | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"ext": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"gr-mydata-invoice-type": "2.3"<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
+| `services`<br />`export`<br />`eu` | `standard` | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"ext": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"gr-mydata-invoice-type": "2.2"<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
+| - | `credit-note` | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"ext": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"gr-mydata-invoice-type": "5.1"<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
+| `simplified` | `standard` | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"ext": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"gr-mydata-invoice-type": "11.3"<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
+| `goods`<br />`simplified` | `standard` | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"ext": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"gr-mydata-invoice-type": "11.1"<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
+| `services`<br />`simplified` | `standard` | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"ext": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"gr-mydata-invoice-type": "11.2"<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
+| `simplified` | `credit-note` | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"ext": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"gr-mydata-invoice-type": "11.4"<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
+| `goods`<br />`simplified`<br />`self-billed` | `credit-note` | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"ext": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"gr-mydata-invoice-type": "11.5"<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
 
-**Output:**
-- **Extensions:** `gr-mydata-invoice-type:2.1`
 </Accordion>
-
-<Accordion title="standard, #goods">
-
-**Filters:**
-- **Types:** `standard`
-- **Tags:** `goods`
-
-**Output:**
-- **Extensions:** `gr-mydata-invoice-type:1.1`
-</Accordion>
-
-<Accordion title="standard, #goods, #export">
-
-**Filters:**
-- **Types:** `standard`
-- **Tags:** `goods`, `export`
-
-**Output:**
-- **Extensions:** `gr-mydata-invoice-type:1.3`
-</Accordion>
-
-<Accordion title="standard, #goods, #export, #eu">
-
-**Filters:**
-- **Types:** `standard`
-- **Tags:** `goods`, `export`, `eu`
-
-**Output:**
-- **Extensions:** `gr-mydata-invoice-type:1.2`
-</Accordion>
-
-<Accordion title="standard, #goods, #self-billed">
-
-**Filters:**
-- **Types:** `standard`
-- **Tags:** `goods`, `self-billed`
-
-**Output:**
-- **Extensions:** `gr-mydata-invoice-type:1.4`
-</Accordion>
-
-<Accordion title="standard, #services">
-
-**Filters:**
-- **Types:** `standard`
-- **Tags:** `services`
-
-**Output:**
-- **Extensions:** `gr-mydata-invoice-type:2.1`
-</Accordion>
-
-<Accordion title="standard, #services, #export">
-
-**Filters:**
-- **Types:** `standard`
-- **Tags:** `services`, `export`
-
-**Output:**
-- **Extensions:** `gr-mydata-invoice-type:2.3`
-</Accordion>
-
-<Accordion title="standard, #services, #export, #eu">
-
-**Filters:**
-- **Types:** `standard`
-- **Tags:** `services`, `export`, `eu`
-
-**Output:**
-- **Extensions:** `gr-mydata-invoice-type:2.2`
-</Accordion>
-
-<Accordion title="credit-note">
-
-**Filters:**
-- **Types:** `credit-note`
-
-**Output:**
-- **Extensions:** `gr-mydata-invoice-type:5.1`
-</Accordion>
-
-<Accordion title="standard, #simplified">
-
-**Filters:**
-- **Types:** `standard`
-- **Tags:** `simplified`
-
-**Output:**
-- **Extensions:** `gr-mydata-invoice-type:11.3`
-</Accordion>
-
-<Accordion title="standard, #goods, #simplified">
-
-**Filters:**
-- **Types:** `standard`
-- **Tags:** `goods`, `simplified`
-
-**Output:**
-- **Extensions:** `gr-mydata-invoice-type:11.1`
-</Accordion>
-
-<Accordion title="standard, #services, #simplified">
-
-**Filters:**
-- **Types:** `standard`
-- **Tags:** `services`, `simplified`
-
-**Output:**
-- **Extensions:** `gr-mydata-invoice-type:11.2`
-</Accordion>
-
-<Accordion title="credit-note, #simplified">
-
-**Filters:**
-- **Types:** `credit-note`
-- **Tags:** `simplified`
-
-**Output:**
-- **Extensions:** `gr-mydata-invoice-type:11.4`
-</Accordion>
-
-<Accordion title="credit-note, #goods, #simplified, #self-billed">
-
-**Filters:**
-- **Types:** `credit-note`
-- **Tags:** `goods`, `simplified`, `self-billed`
-
-**Output:**
-- **Extensions:** `gr-mydata-invoice-type:11.5`
-</Accordion>
+</AccordionGroup>
 
 ## Extensions
 ### VAT rate
@@ -693,6 +579,10 @@ For example:
 </Accordion>
 
 ## Validation Rules
+
+Validation rules check each struct against a set of assertions and report any
+failures with a unique code and message.
+[Read more about validation](/overview/validation).
 
 <AccordionGroup>
 <Accordion title="bill.Invoice">

--- a/addons/it-sdi-v1.mdx
+++ b/addons/it-sdi-v1.mdx
@@ -6,242 +6,41 @@ Key: `it-sdi-v1`
 
 ## Scenarios
 
-### bill/invoice
+Scenarios attach notes and extensions to a document when its filters match.
+[Read more about scenarios](/overview/scenarios).
 
-<Accordion title="Private Invoice">
+<AccordionGroup>
+<Accordion title="bill/invoice">
 
-**Filters:**
-- *(none)*
+| Tags | Type | Output |
+| --- | --- | --- |
+| - | - | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"ext": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"it-sdi-format": "FPR12"<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
+| `b2g` | - | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"ext": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"it-sdi-format": "FPA12"<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
+| - | `standard` | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"ext": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"it-sdi-document-type": "TD01"<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
+| `partial` | `standard` | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"ext": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"it-sdi-document-type": "TD02"<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
+| - | `credit-note` | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"ext": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"it-sdi-document-type": "TD04"<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
+| - | `debit-note` | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"ext": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"it-sdi-document-type": "TD05"<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
+| `freelance` | `standard` | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"ext": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"it-sdi-document-type": "TD06"<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
+| `partial`<br />`freelance` | `standard` | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"ext": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"it-sdi-document-type": "TD03"<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
+| `simplified` | `standard` | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"ext": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"it-sdi-document-type": "TD07"<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
+| `simplified` | `credit-note` | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"ext": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"it-sdi-document-type": "TD08"<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
+| `simplified` | `debit-note` | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"ext": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"it-sdi-document-type": "TD09"<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
+| `self-billed` | `standard` | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"ext": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"it-sdi-document-type": "TD27"<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
+| `self-billed`<br />`reverse-charge` | `standard` | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"ext": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"it-sdi-document-type": "TD16"<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
+| `self-billed`<br />`import` | `standard` | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"ext": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"it-sdi-document-type": "TD17"<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
+| `self-billed`<br />`import`<br />`goods-eu` | `standard` | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"ext": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"it-sdi-document-type": "TD18"<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
+| `self-billed`<br />`import`<br />`goods` | `standard` | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"ext": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"it-sdi-document-type": "TD19"<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
+| `self-billed`<br />`regularization` | `standard` | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"ext": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"it-sdi-document-type": "TD20"<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
+| `self-billed`<br />`ceiling-exceeded` | `standard` | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"ext": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"it-sdi-document-type": "TD21"<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
+| `self-billed`<br />`goods-extracted` | `standard` | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"ext": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"it-sdi-document-type": "TD22"<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
+| `self-billed`<br />`goods-with-tax` | `standard` | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"ext": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"it-sdi-document-type": "TD23"<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
+| `deferred` | `standard` | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"ext": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"it-sdi-document-type": "TD24"<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
+| `deferred`<br />`third-period` | `standard` | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"ext": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"it-sdi-document-type": "TD25"<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
+| `depreciable-assets` | `standard` | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"ext": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"it-sdi-document-type": "TD26"<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
+| `self-billed`<br />`san-marino-paper` | `standard` | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"ext": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"it-sdi-document-type": "TD28"<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
 
-**Output:**
-- **Extensions:** `it-sdi-format:FPR12`
 </Accordion>
-
-<Accordion title="Government Invoice">
-
-**Filters:**
-- **Tags:** `b2g`
-
-**Output:**
-- **Extensions:** `it-sdi-format:FPA12`
-</Accordion>
-
-<Accordion title="Regular Invoice">
-
-**Filters:**
-- **Types:** `standard`
-
-**Output:**
-- **Extensions:** `it-sdi-document-type:TD01`
-</Accordion>
-
-<Accordion title="Advance or down payment on invoice">
-
-**Filters:**
-- **Types:** `standard`
-- **Tags:** `partial`
-
-**Output:**
-- **Extensions:** `it-sdi-document-type:TD02`
-</Accordion>
-
-<Accordion title="Credit Note">
-
-**Filters:**
-- **Types:** `credit-note`
-
-**Output:**
-- **Extensions:** `it-sdi-document-type:TD04`
-</Accordion>
-
-<Accordion title="Debit Note">
-
-**Filters:**
-- **Types:** `debit-note`
-
-**Output:**
-- **Extensions:** `it-sdi-document-type:TD05`
-</Accordion>
-
-<Accordion title="Freelancer invoice with retained taxes">
-
-**Filters:**
-- **Types:** `standard`
-- **Tags:** `freelance`
-
-**Output:**
-- **Extensions:** `it-sdi-document-type:TD06`
-</Accordion>
-
-<Accordion title="Advance or down payment on freelance invoice">
-
-**Filters:**
-- **Types:** `standard`
-- **Tags:** `partial`, `freelance`
-
-**Output:**
-- **Extensions:** `it-sdi-document-type:TD03`
-</Accordion>
-
-<Accordion title="Simplified Invoice">
-
-**Filters:**
-- **Types:** `standard`
-- **Tags:** `simplified`
-
-**Output:**
-- **Extensions:** `it-sdi-document-type:TD07`
-</Accordion>
-
-<Accordion title="Simplified Credit Note">
-
-**Filters:**
-- **Types:** `credit-note`
-- **Tags:** `simplified`
-
-**Output:**
-- **Extensions:** `it-sdi-document-type:TD08`
-</Accordion>
-
-<Accordion title="Simplified Debit Note">
-
-**Filters:**
-- **Types:** `debit-note`
-- **Tags:** `simplified`
-
-**Output:**
-- **Extensions:** `it-sdi-document-type:TD09`
-</Accordion>
-
-<Accordion title="Self-billed for self consumption or for free transfer without recourse">
-
-**Filters:**
-- **Types:** `standard`
-- **Tags:** `self-billed`
-
-**Output:**
-- **Extensions:** `it-sdi-document-type:TD27`
-</Accordion>
-
-<Accordion title="Reverse charge">
-
-**Filters:**
-- **Types:** `standard`
-- **Tags:** `self-billed`, `reverse-charge`
-
-**Output:**
-- **Extensions:** `it-sdi-document-type:TD16`
-</Accordion>
-
-<Accordion title="Self-billed Import">
-
-**Filters:**
-- **Types:** `standard`
-- **Tags:** `self-billed`, `import`
-
-**Output:**
-- **Extensions:** `it-sdi-document-type:TD17`
-</Accordion>
-
-<Accordion title="Self-billed EU Goods Import">
-
-**Filters:**
-- **Types:** `standard`
-- **Tags:** `self-billed`, `import`, `goods-eu`
-
-**Output:**
-- **Extensions:** `it-sdi-document-type:TD18`
-</Accordion>
-
-<Accordion title="Self-billed Goods Import">
-
-**Filters:**
-- **Types:** `standard`
-- **Tags:** `self-billed`, `import`, `goods`
-
-**Output:**
-- **Extensions:** `it-sdi-document-type:TD19`
-</Accordion>
-
-<Accordion title="Self-billed Regularization">
-
-**Filters:**
-- **Types:** `standard`
-- **Tags:** `self-billed`, `regularization`
-
-**Output:**
-- **Extensions:** `it-sdi-document-type:TD20`
-</Accordion>
-
-<Accordion title="Self-billed invoice when ceiling exceeded">
-
-**Filters:**
-- **Types:** `standard`
-- **Tags:** `self-billed`, `ceiling-exceeded`
-
-**Output:**
-- **Extensions:** `it-sdi-document-type:TD21`
-</Accordion>
-
-<Accordion title="Self-billed for goods extracted from VAT warehouse">
-
-**Filters:**
-- **Types:** `standard`
-- **Tags:** `self-billed`, `goods-extracted`
-
-**Output:**
-- **Extensions:** `it-sdi-document-type:TD22`
-</Accordion>
-
-<Accordion title="Self-billed for goods extracted from VAT warehouse with VAT payment">
-
-**Filters:**
-- **Types:** `standard`
-- **Tags:** `self-billed`, `goods-with-tax`
-
-**Output:**
-- **Extensions:** `it-sdi-document-type:TD23`
-</Accordion>
-
-<Accordion title="Deferred invoice ex art.21, c.4, lett. a) DPR 633/72">
-
-**Filters:**
-- **Types:** `standard`
-- **Tags:** `deferred`
-
-**Output:**
-- **Extensions:** `it-sdi-document-type:TD24`
-</Accordion>
-
-<Accordion title="Deferred invoice ex art.21, c.4, third period lett. b) DPR 633/72">
-
-**Filters:**
-- **Types:** `standard`
-- **Tags:** `deferred`, `third-period`
-
-**Output:**
-- **Extensions:** `it-sdi-document-type:TD25`
-</Accordion>
-
-<Accordion title="Sale of depreciable assets and for internal transfers (ex art.36 DPR 633/72">
-
-**Filters:**
-- **Types:** `standard`
-- **Tags:** `depreciable-assets`
-
-**Output:**
-- **Extensions:** `it-sdi-document-type:TD26`
-</Accordion>
-
-<Accordion title="Purchases from San Marino with VAT (paper invoice)">
-
-**Filters:**
-- **Types:** `standard`
-- **Tags:** `self-billed`, `san-marino-paper`
-
-**Output:**
-- **Extensions:** `it-sdi-document-type:TD28`
-</Accordion>
+</AccordionGroup>
 
 ## Extensions
 ### SDI Transmission Format
@@ -455,6 +254,10 @@ used to determine the correct schema to use when validating the document.
 </Accordion>
 
 ## Validation Rules
+
+Validation rules check each struct against a set of assertions and report any
+failures with a unique code and message.
+[Read more about validation](/overview/validation).
 
 <AccordionGroup>
 <Accordion title="bill.Invoice">

--- a/addons/it-ticket-v1.mdx
+++ b/addons/it-ticket-v1.mdx
@@ -68,6 +68,10 @@ Reference code provided by the AdE to be able to identify the specific line in c
 
 ## Validation Rules
 
+Validation rules check each struct against a set of assertions and report any
+failures with a unique code and message.
+[Read more about validation](/overview/validation).
+
 <AccordionGroup>
 <Accordion title="bill.Invoice">
 

--- a/addons/mx-cfdi-v4.mdx
+++ b/addons/mx-cfdi-v4.mdx
@@ -6,45 +6,21 @@ Key: `mx-cfdi-v4`
 
 ## Scenarios
 
-### bill/invoice
+Scenarios attach notes and extensions to a document when its filters match.
+[Read more about scenarios](/overview/scenarios).
 
-<Accordion title="standard">
+<AccordionGroup>
+<Accordion title="bill/invoice">
 
-**Filters:**
-- **Types:** `standard`
+| Tags | Type | Output |
+| --- | --- | --- |
+| - | `standard` | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"ext": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"mx-cfdi-doc-type": "I"<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
+| - | `credit-note` | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"ext": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"mx-cfdi-doc-type": "E",<br/>&nbsp;&nbsp;&nbsp;&nbsp;"mx-cfdi-rel-type": "01"<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
+| [custom](https://github.com/invopop/gobl/blob/v0.401.0/addons/mx/cfdi/scenarios.go#L32) | `standard`<br />`credit-note` | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"ext": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"mx-cfdi-payment-method": "PUE"<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
+| [custom](https://github.com/invopop/gobl/blob/v0.401.0/addons/mx/cfdi/scenarios.go#L45) | `standard`<br />`credit-note` | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"ext": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"mx-cfdi-payment-method": "PPD"<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
 
-**Output:**
-- **Extensions:** `mx-cfdi-doc-type:I`
 </Accordion>
-
-<Accordion title="credit-note">
-
-**Filters:**
-- **Types:** `credit-note`
-
-**Output:**
-- **Extensions:** `mx-cfdi-rel-type:01`, `mx-cfdi-doc-type:E`
-</Accordion>
-
-<Accordion title="standard, credit-note">
-
-**Filters:**
-- **Types:** `standard`, `credit-note`
-- **Filter:** *(custom)*
-
-**Output:**
-- **Extensions:** `mx-cfdi-payment-method:PUE`
-</Accordion>
-
-<Accordion title="standard, credit-note">
-
-**Filters:**
-- **Types:** `standard`, `credit-note`
-- **Filter:** *(custom)*
-
-**Output:**
-- **Extensions:** `mx-cfdi-payment-method:PPD`
-</Accordion>
+</AccordionGroup>
 
 ## Extensions
 ### Document Type
@@ -251,6 +227,10 @@ Pattern: `\d{4}`
 </Accordion>
 
 ## Validation Rules
+
+Validation rules check each struct against a set of assertions and report any
+failures with a unique code and message.
+[Read more about validation](/overview/validation).
 
 <AccordionGroup>
 <Accordion title="bill.Invoice">

--- a/addons/pl-favat-v3.mdx
+++ b/addons/pl-favat-v3.mdx
@@ -21,75 +21,24 @@ Stamp keys from the previous invoice that need to be referenced:
 
 ## Scenarios
 
-### bill/invoice
+Scenarios attach notes and extensions to a document when its filters match.
+[Read more about scenarios](/overview/scenarios).
 
-<Accordion title="Regular Invoice">
+<AccordionGroup>
+<Accordion title="bill/invoice">
 
-**Filters:**
-- **Types:** `standard`
+| Tags | Type | Output |
+| --- | --- | --- |
+| - | `standard` | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"ext": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"pl-favat-invoice-type": "VAT"<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
+| `partial` | `standard` | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"ext": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"pl-favat-invoice-type": "ZAL"<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
+| `settlement` | `standard` | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"ext": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"pl-favat-invoice-type": "ROZ"<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
+| `simplified` | `standard` | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"ext": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"pl-favat-invoice-type": "UPR"<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
+| - | `credit-note` | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"ext": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"pl-favat-invoice-type": "KOR"<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
+| `partial` | `credit-note` | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"ext": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"pl-favat-invoice-type": "KOR_ZAL"<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
+| `settlement` | `credit-note` | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"ext": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"pl-favat-invoice-type": "KOR_ROZ"<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
 
-**Output:**
-- **Extensions:** `pl-favat-invoice-type:VAT`
 </Accordion>
-
-<Accordion title="Prepayment Invoice">
-
-**Filters:**
-- **Types:** `standard`
-- **Tags:** `partial`
-
-**Output:**
-- **Extensions:** `pl-favat-invoice-type:ZAL`
-</Accordion>
-
-<Accordion title="Settlement Invoice">
-
-**Filters:**
-- **Types:** `standard`
-- **Tags:** `settlement`
-
-**Output:**
-- **Extensions:** `pl-favat-invoice-type:ROZ`
-</Accordion>
-
-<Accordion title="Simplified Invoice">
-
-**Filters:**
-- **Types:** `standard`
-- **Tags:** `simplified`
-
-**Output:**
-- **Extensions:** `pl-favat-invoice-type:UPR`
-</Accordion>
-
-<Accordion title="Credit note">
-
-**Filters:**
-- **Types:** `credit-note`
-
-**Output:**
-- **Extensions:** `pl-favat-invoice-type:KOR`
-</Accordion>
-
-<Accordion title="Prepayment credit note">
-
-**Filters:**
-- **Types:** `credit-note`
-- **Tags:** `partial`
-
-**Output:**
-- **Extensions:** `pl-favat-invoice-type:KOR_ZAL`
-</Accordion>
-
-<Accordion title="Settlement credit note">
-
-**Filters:**
-- **Types:** `credit-note`
-- **Tags:** `settlement`
-
-**Output:**
-- **Extensions:** `pl-favat-invoice-type:KOR_ROZ`
-</Accordion>
+</AccordionGroup>
 
 ## Extensions
 ### Tax categories for KSeF
@@ -750,6 +699,10 @@ Example of a credit note effective on correction date:
 </Accordion>
 
 ## Validation Rules
+
+Validation rules check each struct against a set of assertions and report any
+failures with a unique code and message.
+[Read more about validation](/overview/validation).
 
 <AccordionGroup>
 <Accordion title="bill.Invoice">

--- a/addons/pt-saft-v1.mdx
+++ b/addons/pt-saft-v1.mdx
@@ -32,63 +32,23 @@ The types of invoices that can be created with a preceding definition:
 
 ## Scenarios
 
-### bill/invoice
+Scenarios attach notes and extensions to a document when its filters match.
+[Read more about scenarios](/overview/scenarios).
 
-<Accordion title="standard">
+<AccordionGroup>
+<Accordion title="bill/invoice">
 
-**Filters:**
-- **Types:** `standard`
+| Tags | Type | Output |
+| --- | --- | --- |
+| - | `standard` | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"ext": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"pt-saft-invoice-type": "FT"<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
+| `simplified` | `standard` | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"ext": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"pt-saft-invoice-type": "FS"<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
+| [custom](https://github.com/invopop/gobl/blob/v0.401.0/addons/pt/saft/scenarios.go#L32) | `standard` | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"ext": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"pt-saft-invoice-type": "FR"<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
+| - | `debit-note` | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"ext": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"pt-saft-invoice-type": "ND"<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
+| - | `credit-note` | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"ext": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"pt-saft-invoice-type": "NC"<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
+| - | `proforma` | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"ext": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"pt-saft-work-type": "PF"<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
 
-**Output:**
-- **Extensions:** `pt-saft-invoice-type:FT`
 </Accordion>
-
-<Accordion title="standard, #simplified">
-
-**Filters:**
-- **Types:** `standard`
-- **Tags:** `simplified`
-
-**Output:**
-- **Extensions:** `pt-saft-invoice-type:FS`
-</Accordion>
-
-<Accordion title="standard">
-
-**Filters:**
-- **Types:** `standard`
-- **Filter:** *(custom)*
-
-**Output:**
-- **Extensions:** `pt-saft-invoice-type:FR`
-</Accordion>
-
-<Accordion title="debit-note">
-
-**Filters:**
-- **Types:** `debit-note`
-
-**Output:**
-- **Extensions:** `pt-saft-invoice-type:ND`
-</Accordion>
-
-<Accordion title="credit-note">
-
-**Filters:**
-- **Types:** `credit-note`
-
-**Output:**
-- **Extensions:** `pt-saft-invoice-type:NC`
-</Accordion>
-
-<Accordion title="proforma">
-
-**Filters:**
-- **Types:** `proforma`
-
-**Output:**
-- **Extensions:** `pt-saft-work-type:PF`
-</Accordion>
+</AccordionGroup>
 
 ## Extensions
 ### Invoice Type
@@ -596,6 +556,10 @@ Example:
 </Accordion>
 
 ## Validation Rules
+
+Validation rules check each struct against a set of assertions and report any
+failures with a unique code and message.
+[Read more about validation](/overview/validation).
 
 <AccordionGroup>
 <Accordion title="bill.Invoice">

--- a/cmd/generate/addons.go
+++ b/cmd/generate/addons.go
@@ -29,7 +29,7 @@ func newAddonGenerator(a *tax.AddonDef) *addonGenerator {
 		"joinKeys":      joinKeys,
 		"codeMap":       codeMap,
 		"extMap":        extMap,
-		"scenarioTitle": scenarioTitle,
+		"scenarioTable": scenarioTable,
 		"codeMessage":   codeMessage,
 		"testList":      testList,
 		"fieldCell":     fieldCell,
@@ -97,52 +97,17 @@ func (g *addonGenerator) scenarios() error {
 
 		## Scenarios
 
+		Scenarios attach notes and extensions to a document when its filters match.
+		[Read more about scenarios](/overview/scenarios).
+
+		<AccordionGroup>
 		{{- range .Scenarios }}
+		<Accordion title="{{ .Schema }}">
 
-		### {{ .Schema }}
-
-		{{- range .List }}
-
-		<Accordion title="{{ scenarioTitle . }}">
-
-		**Filters:**
-
-		{{- if .Types }}
-		- **Types:** {{ joinKeys .Types }}
-		{{- end }}
-		{{- if .Tags }}
-		- **Tags:** {{ joinKeys .Tags }}
-		{{- end }}
-		{{- if .ExtKey }}
-		- **Extension Key:** ~{{ .ExtKey }}~
-		{{- end }}
-		{{- if .ExtCode }}
-		- **Extension Code:** ~{{ .ExtCode }}~
-		{{- end }}
-		{{- if .Filter }}
-		- **Filter:** *(custom)*
-		{{- end }}
-		{{- if not .Types }}{{ if not .Tags }}{{ if not .ExtKey }}{{ if not .Filter }}
-		- *(none)*
-		{{- end }}{{ end }}{{ end }}{{ end }}
-
-		**Output:**
-
-		{{- if .Note }}
-		- **Note:** {{ .Note.Text }}{{ if .Note.Key }} ({{ .Note.Key }}){{ end }}
-		{{- end }}
-		{{- if .Codes }}
-		- **Codes:** {{ codeMap .Codes }}
-		{{- end }}
-		{{- if .Ext }}
-		- **Extensions:** {{ extMap .Ext }}
-		{{- end }}
-		{{- if not .Note }}{{ if not .Codes }}{{ if not .Ext }}
-		- *(none)*
-		{{- end }}{{ end }}{{ end }}
+		{{ scenarioTable . }}
 		</Accordion>
 		{{- end }}
-		{{- end }}
+		</AccordionGroup>
 
 	`))
 }

--- a/cmd/generate/generator.go
+++ b/cmd/generate/generator.go
@@ -130,6 +130,10 @@ func (g *generator) validationRules(sections []RuleSection) error {
 
 		## Validation Rules
 
+		Validation rules check each struct against a set of assertions and report any
+		failures with a unique code and message.
+		[Read more about validation](/overview/validation).
+
 		<AccordionGroup>
 		{{- range .}}
 		{{- $sec := .}}

--- a/cmd/generate/regimes.go
+++ b/cmd/generate/regimes.go
@@ -49,7 +49,7 @@ func newRegimeGenerator(r *tax.RegimeDef) *regimeGenerator {
 		"joinKeys":      joinKeys,
 		"codeMap":       codeMap,
 		"extMap":        extMap,
-		"scenarioTitle": scenarioTitle,
+		"scenarioTable": scenarioTable,
 		"codeMessage":   codeMessage,
 		"testList":      testList,
 		"fieldCell":     fieldCell,
@@ -368,52 +368,17 @@ func (g *regimeGenerator) scenarios() error {
 
 		## Scenarios
 
+		Scenarios attach notes and extensions to a document when its filters match.
+		[Read more about scenarios](/overview/scenarios).
+
+		<AccordionGroup>
 		{{- range .Scenarios }}
+		<Accordion title="{{ .Schema }}">
 
-		### {{ .Schema }}
-
-		{{- range .List }}
-
-		<Accordion title="{{ scenarioTitle . }}">
-
-		**Filters:**
-
-		{{- if .Types }}
-		- **Types:** {{ joinKeys .Types }}
-		{{- end }}
-		{{- if .Tags }}
-		- **Tags:** {{ joinKeys .Tags }}
-		{{- end }}
-		{{- if .ExtKey }}
-		- **Extension Key:** ~{{ .ExtKey }}~
-		{{- end }}
-		{{- if .ExtCode }}
-		- **Extension Code:** ~{{ .ExtCode }}~
-		{{- end }}
-		{{- if .Filter }}
-		- **Filter:** *(custom)*
-		{{- end }}
-		{{- if not .Types }}{{ if not .Tags }}{{ if not .ExtKey }}{{ if not .Filter }}
-		- *(none)*
-		{{- end }}{{ end }}{{ end }}{{ end }}
-
-		**Output:**
-
-		{{- if .Note }}
-		- **Note:** {{ .Note.Text }}{{ if .Note.Key }} ({{ .Note.Key }}){{ end }}
-		{{- end }}
-		{{- if .Codes }}
-		- **Codes:** {{ codeMap .Codes }}
-		{{- end }}
-		{{- if .Ext }}
-		- **Extensions:** {{ extMap .Ext }}
-		{{- end }}
-		{{- if not .Note }}{{ if not .Codes }}{{ if not .Ext }}
-		- *(none)*
-		{{- end }}{{ end }}{{ end }}
+		{{ scenarioTable . }}
 		</Accordion>
 		{{- end }}
-		{{- end }}
+		</AccordionGroup>
 
 	`))
 }

--- a/cmd/generate/utils.go
+++ b/cmd/generate/utils.go
@@ -1,8 +1,11 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"html"
+	"reflect"
+	"runtime"
 	"strings"
 
 	"github.com/invopop/gobl/cbc"
@@ -91,29 +94,177 @@ func testList(parts []string, calculated bool) string {
 	return buf.String()
 }
 
-// scenarioTitle builds a concise title for a scenario accordion.
-func scenarioTitle(sc *tax.Scenario) string {
-	if sc.Name != nil {
-		if n := sc.Name.String(); n != "" {
-			return n
-		}
+// customFilterLabel produces the marker shown in the Tags column for a scenario
+// that uses a custom Filter function. It prefers the scenario's own Desc/Name
+// (i18n strings the GOBL data model exposes for documentation) and falls back
+// to a "(custom)" link pointing at the function's source on GitHub so an
+// author who forgot to fill in Desc still gives readers somewhere to look.
+func customFilterLabel(sc *tax.Scenario) string {
+	if desc := sc.Desc.String(); desc != "" {
+		return fmt.Sprintf("*%s*", desc)
 	}
+	if name := sc.Name.String(); name != "" {
+		return fmt.Sprintf("*%s*", name)
+	}
+	if src := customFilterSource(sc.Filter); src != "" {
+		return fmt.Sprintf("[custom](%s)", src)
+	}
+	return "custom"
+}
+
+// customFilterSource returns a GitHub permalink (pinned at the gobl version
+// this generator is built against) to the source location of the supplied
+// custom filter function, or "" if the source can't be resolved.
+func customFilterSource(filter func(doc any) bool) string {
+	if filter == nil {
+		return ""
+	}
+	pc := reflect.ValueOf(filter).Pointer()
+	fn := runtime.FuncForPC(pc)
+	if fn == nil {
+		return ""
+	}
+	file, line := fn.FileLine(pc)
+	const marker = "github.com/invopop/gobl@"
+	idx := strings.Index(file, marker)
+	if idx < 0 {
+		return ""
+	}
+	rest := file[idx+len(marker):]
+	parts := strings.SplitN(rest, "/", 2)
+	if len(parts) != 2 {
+		return ""
+	}
+	return fmt.Sprintf("https://github.com/invopop/gobl/blob/%s/%s#L%d", parts[0], parts[1], line)
+}
+
+// scenarioTagsCell renders the Tags column of a scenario row, including any
+// ExtKey/ExtCode filter or custom-filter marker so no filter information is
+// silently dropped.
+func scenarioTagsCell(sc *tax.Scenario) string {
 	var parts []string
-	for _, t := range sc.Types {
-		parts = append(parts, t.String())
-	}
 	for _, t := range sc.Tags {
-		parts = append(parts, "#"+t.String())
+		parts = append(parts, fmt.Sprintf("`%s`", t.String()))
 	}
 	if sc.ExtKey != "" {
 		label := sc.ExtKey.String()
 		if sc.ExtCode != "" {
 			label += "=" + sc.ExtCode.String()
 		}
-		parts = append(parts, label)
+		parts = append(parts, fmt.Sprintf("`%s`", label))
+	}
+	if sc.Filter != nil {
+		parts = append(parts, customFilterLabel(sc))
 	}
 	if len(parts) == 0 {
-		return "Scenario"
+		return "-"
 	}
-	return strings.Join(parts, ", ")
+	return strings.Join(parts, "<br />")
+}
+
+func scenarioTypesCell(sc *tax.Scenario) string {
+	if len(sc.Types) == 0 {
+		return "-"
+	}
+	var s []string
+	for _, t := range sc.Types {
+		s = append(s, fmt.Sprintf("`%s`", t.String()))
+	}
+	return strings.Join(s, "<br />")
+}
+
+func scenarioCategoriesCell(sc *tax.Scenario) string {
+	if len(sc.Categories) == 0 {
+		return "-"
+	}
+	var s []string
+	for _, c := range sc.Categories {
+		s = append(s, fmt.Sprintf("`%s`", c.String()))
+	}
+	return strings.Join(s, "<br />")
+}
+
+// scenarioOutputJSON is used to marshal scenario outputs in a stable field
+// order (note → codes → ext) regardless of which fields are present.
+type scenarioOutputJSON struct {
+	Note  *tax.Note      `json:"note,omitempty"`
+	Codes cbc.CodeMap    `json:"codes,omitempty"`
+	Ext   tax.Extensions `json:"ext,omitempty"`
+}
+
+// scenarioOutputCell renders the Output column as an indented JSON snippet
+// showing the scenario outputs in the shape GOBL emits when applying them to a
+// document. Newlines are rendered as <br/> and leading spaces as &nbsp; so the
+// content fits on a single source line in a markdown table cell while
+// preserving indentation. Braces and pipes are escaped so MDX and the table
+// parser don't choke.
+func scenarioOutputCell(sc *tax.Scenario) string {
+	if sc.Note == nil && len(sc.Codes) == 0 && len(sc.Ext) == 0 {
+		return "-"
+	}
+	out := scenarioOutputJSON{Note: sc.Note, Codes: sc.Codes, Ext: sc.Ext}
+	raw, _ := json.MarshalIndent(out, "", "  ")
+	lines := strings.Split(string(raw), "\n")
+	for i, line := range lines {
+		n := 0
+		for n < len(line) && line[n] == ' ' {
+			n++
+		}
+		lines[i] = strings.Repeat("&nbsp;", n) + line[n:]
+	}
+	body := strings.Join(lines, "<br/>")
+	body = strings.ReplaceAll(body, "{", "&#123;")
+	body = strings.ReplaceAll(body, "}", "&#125;")
+	body = strings.ReplaceAll(body, "|", "\\|")
+	return `<code class="code-block">` + body + "</code>"
+}
+
+// scenarioTable renders a complete markdown table for a scenario set, omitting
+// any filter columns whose values are empty across all rows.
+func scenarioTable(set *tax.ScenarioSet) string {
+	if set == nil || len(set.List) == 0 {
+		return ""
+	}
+	var showTags, showTypes, showCategories bool
+	for _, sc := range set.List {
+		if len(sc.Tags) > 0 || sc.ExtKey != "" || sc.Filter != nil {
+			showTags = true
+		}
+		if len(sc.Types) > 0 {
+			showTypes = true
+		}
+		if len(sc.Categories) > 0 {
+			showCategories = true
+		}
+	}
+	var headers []string
+	if showTags {
+		headers = append(headers, "Tags")
+	}
+	if showTypes {
+		headers = append(headers, "Type")
+	}
+	if showCategories {
+		headers = append(headers, "Categories")
+	}
+	headers = append(headers, "Output")
+
+	var b strings.Builder
+	b.WriteString("| " + strings.Join(headers, " | ") + " |\n")
+	b.WriteString("|" + strings.Repeat(" --- |", len(headers)) + "\n")
+	for _, sc := range set.List {
+		var cells []string
+		if showTags {
+			cells = append(cells, scenarioTagsCell(sc))
+		}
+		if showTypes {
+			cells = append(cells, scenarioTypesCell(sc))
+		}
+		if showCategories {
+			cells = append(cells, scenarioCategoriesCell(sc))
+		}
+		cells = append(cells, scenarioOutputCell(sc))
+		b.WriteString("| " + strings.Join(cells, " | ") + " |\n")
+	}
+	return b.String()
 }

--- a/cmd/generate/utils.go
+++ b/cmd/generate/utils.go
@@ -210,11 +210,15 @@ func scenarioOutputCell(sc *tax.Scenario) string {
 		for n < len(line) && line[n] == ' ' {
 			n++
 		}
-		lines[i] = strings.Repeat("&nbsp;", n) + line[n:]
+		content := line[n:]
+		content = strings.ReplaceAll(content, "&", "&amp;")
+		content = strings.ReplaceAll(content, "<", "&lt;")
+		content = strings.ReplaceAll(content, ">", "&gt;")
+		content = strings.ReplaceAll(content, "{", "&#123;")
+		content = strings.ReplaceAll(content, "}", "&#125;")
+		lines[i] = strings.Repeat("&nbsp;", n) + content
 	}
 	body := strings.Join(lines, "<br/>")
-	body = strings.ReplaceAll(body, "{", "&#123;")
-	body = strings.ReplaceAll(body, "}", "&#125;")
 	body = strings.ReplaceAll(body, "|", "\\|")
 	return `<code class="code-block">` + body + "</code>"
 }

--- a/docs.json
+++ b/docs.json
@@ -47,6 +47,7 @@
               "overview/canonicalization",
               "overview/support",
               "overview/inside",
+              "overview/scenarios",
               "overview/validation"
             ]
           },

--- a/overview/scenarios.mdx
+++ b/overview/scenarios.mdx
@@ -1,0 +1,56 @@
+---
+title: "Scenarios"
+---
+
+Scenarios are how GOBL applies tax-regime and addon-specific output to a document at build time without you having to write it yourself. Each [tax regime](/regimes/overview) and [addon](/addons/overview) declares a list of scenarios; whenever a document is built, GOBL evaluates them and merges any matching outputs into the document.
+
+## Anatomy of a scenario
+
+A scenario has two parts:
+
+- **Filters** decide whether the scenario applies to a given document.
+- **Outputs** describe what to attach to the document when the filters match.
+
+Both regimes and addons can define scenarios. Scenarios are organised per schema (for example `bill/invoice`), so a regime can hold one set of scenarios for invoices and a different set for orders or payments.
+
+## Filters
+
+A scenario matches when **every** filter it defines is satisfied by the document. An empty filter is treated as "any value is fine", so a scenario with no filters matches every document of the configured schema.
+
+| Filter | Matches against |
+| --- | --- |
+| **Type** | The document's [`type`](/draft-0/bill/invoice#type) (e.g. `standard`, `corrective`, `credit-note`). |
+| **Tags** | Tags applied to the document via [`$tags`](/draft-0/bill/invoice#tags) (e.g. `reverse-charge`, `simplified`, `self-billed`). |
+| **Categories** | The set of [tax categories](/draft-0/tax/category_def) present across the document's line, charge, and discount taxes (e.g. `VAT`, `IGIC`). |
+| **Extension key / code** | A specific [tax extension](/draft-0/tax/extensions) being present, optionally with a specific value. |
+| **Custom filter** | A regime- or addon-defined function for cases the basic filters can't express. |
+
+The **Categories** filter is what allows a country with multiple tax categories — like Spain (mainland VAT and Canary IGIC) — to express *"this note applies to reverse-charge invoices, but only when the lines are using VAT"*. The same scenario can then be paired with another that scopes the note to IGIC.
+
+Note that category matching looks at the document's lines, charges, and discounts: even though scenario outputs always land at the document level, the *applicability* is determined by what's used inside the document.
+
+## Outputs
+
+When a scenario matches, GOBL applies its outputs to the document:
+
+| Output | Where it lands |
+| --- | --- |
+| **Note** | Appended to the document's [`tax.notes`](/draft-0/bill/invoice#tax) array. The note carries its own `cat` (category) and `key`, and notes with the same category-and-key pair are deduplicated. |
+| **Extensions** | Merged into the document's [`tax.ext`](/draft-0/bill/invoice#tax) map. Useful for addons that need to attach a code identifying the document under a reporting standard. |
+| **Codes** | Made available through the scenario summary for downstream conversion processes; not auto-merged onto the document itself. |
+
+Outputs always land on the document, never on individual lines. That keeps the document model simple: a scenario filter may inspect line-level details to decide whether to fire, but the resulting note or extension belongs to the invoice as a whole.
+
+## How matching works
+
+When you build a document:
+
+1. GOBL collects every scenario defined by the document's regime and any enabled addons for the document's schema.
+2. Each scenario is evaluated against the document. All filters must match for the scenario to apply.
+3. For every matching scenario, the outputs are merged into the document. Notes are deduplicated by `cat` + `key`; extensions overwrite any earlier value for the same key.
+
+This means multiple scenarios can fire on the same document — a Spanish reverse-charge invoice using both VAT and IGIC will receive both the VAT-scoped note and the IGIC-scoped one.
+
+## Where to see them
+
+Each [regime](/regimes/overview) and [addon](/addons/overview) page has a **Scenarios** section listing every scenario it defines, broken down by schema. The columns shown depend on which filters that regime or addon actually uses — empty filter columns are hidden so the table stays focused on the values that matter for that country or standard.

--- a/regimes/ae.mdx
+++ b/regimes/ae.mdx
@@ -47,27 +47,25 @@ The types of invoices that can be created with a preceding definition:
 
 ## Scenarios
 
-### bill/invoice
+Scenarios attach notes and extensions to a document when its filters match.
+[Read more about scenarios](/overview/scenarios).
 
-<Accordion title="#reverse-charge">
+<AccordionGroup>
+<Accordion title="bill/invoice">
 
-**Filters:**
-- **Tags:** `reverse-charge`
+| Tags | Categories | Output |
+| --- | --- | --- |
+| `reverse-charge` | `VAT` | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"note": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"cat": "VAT",<br/>&nbsp;&nbsp;&nbsp;&nbsp;"key": "reverse-charge",<br/>&nbsp;&nbsp;&nbsp;&nbsp;"text": "Reverse Charge"<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
+| `simplified` | `VAT` | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"note": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"cat": "VAT",<br/>&nbsp;&nbsp;&nbsp;&nbsp;"key": "simplified",<br/>&nbsp;&nbsp;&nbsp;&nbsp;"text": "Simplified Tax Invoice"<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
 
-**Output:**
-- **Note:** Reverse Charge (reverse-charge)
 </Accordion>
-
-<Accordion title="#simplified">
-
-**Filters:**
-- **Tags:** `simplified`
-
-**Output:**
-- **Note:** Simplified Tax Invoice (simplified)
-</Accordion>
+</AccordionGroup>
 
 ## Validation Rules
+
+Validation rules check each struct against a set of assertions and report any
+failures with a unique code and message.
+[Read more about validation](/overview/validation).
 
 <AccordionGroup>
 <Accordion title="tax.Identity">

--- a/regimes/ar.mdx
+++ b/regimes/ar.mdx
@@ -72,6 +72,10 @@ The types of invoices that can be created with a preceding definition:
 
 ## Validation Rules
 
+Validation rules check each struct against a set of assertions and report any
+failures with a unique code and message.
+[Read more about validation](/overview/validation).
+
 <AccordionGroup>
 <Accordion title="bill.Invoice">
 

--- a/regimes/at.mdx
+++ b/regimes/at.mdx
@@ -45,18 +45,24 @@ The types of invoices that can be created with a preceding definition:
 
 ## Scenarios
 
-### bill/invoice
+Scenarios attach notes and extensions to a document when its filters match.
+[Read more about scenarios](/overview/scenarios).
 
-<Accordion title="#reverse-charge">
+<AccordionGroup>
+<Accordion title="bill/invoice">
 
-**Filters:**
-- **Tags:** `reverse-charge`
+| Tags | Categories | Output |
+| --- | --- | --- |
+| `reverse-charge` | `VAT` | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"note": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"cat": "VAT",<br/>&nbsp;&nbsp;&nbsp;&nbsp;"key": "reverse-charge",<br/>&nbsp;&nbsp;&nbsp;&nbsp;"text": "Reverse charge: Customer to account for VAT to the relevant tax authority."<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
 
-**Output:**
-- **Note:** Reverse charge: Customer to account for VAT to the relevant tax authority. (reverse-charge)
 </Accordion>
+</AccordionGroup>
 
 ## Validation Rules
+
+Validation rules check each struct against a set of assertions and report any
+failures with a unique code and message.
+[Read more about validation](/overview/validation).
 
 <AccordionGroup>
 <Accordion title="tax.Identity">

--- a/regimes/be.mdx
+++ b/regimes/be.mdx
@@ -49,18 +49,24 @@ The types of invoices that can be created with a preceding definition:
 
 ## Scenarios
 
-### bill/invoice
+Scenarios attach notes and extensions to a document when its filters match.
+[Read more about scenarios](/overview/scenarios).
 
-<Accordion title="#reverse-charge">
+<AccordionGroup>
+<Accordion title="bill/invoice">
 
-**Filters:**
-- **Tags:** `reverse-charge`
+| Tags | Categories | Output |
+| --- | --- | --- |
+| `reverse-charge` | `VAT` | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"note": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"cat": "VAT",<br/>&nbsp;&nbsp;&nbsp;&nbsp;"key": "reverse-charge",<br/>&nbsp;&nbsp;&nbsp;&nbsp;"text": "Reverse charge: Customer to account for VAT to the relevant tax authority."<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
 
-**Output:**
-- **Note:** Reverse charge: Customer to account for VAT to the relevant tax authority. (reverse-charge)
 </Accordion>
+</AccordionGroup>
 
 ## Validation Rules
+
+Validation rules check each struct against a set of assertions and report any
+failures with a unique code and message.
+[Read more about validation](/overview/validation).
 
 <AccordionGroup>
 <Accordion title="tax.Identity">

--- a/regimes/br.mdx
+++ b/regimes/br.mdx
@@ -69,6 +69,10 @@ Pattern: `^\d{7}$`
 
 ## Validation Rules
 
+Validation rules check each struct against a set of assertions and report any
+failures with a unique code and message.
+[Read more about validation](/overview/validation).
+
 <AccordionGroup>
 <Accordion title="org.Party">
 

--- a/regimes/ch.mdx
+++ b/regimes/ch.mdx
@@ -51,18 +51,24 @@ The types of invoices that can be created with a preceding definition:
 
 ## Scenarios
 
-### bill/invoice
+Scenarios attach notes and extensions to a document when its filters match.
+[Read more about scenarios](/overview/scenarios).
 
-<Accordion title="#reverse-charge">
+<AccordionGroup>
+<Accordion title="bill/invoice">
 
-**Filters:**
-- **Tags:** `reverse-charge`
+| Tags | Categories | Output |
+| --- | --- | --- |
+| `reverse-charge` | `VAT` | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"note": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"cat": "VAT",<br/>&nbsp;&nbsp;&nbsp;&nbsp;"key": "reverse-charge",<br/>&nbsp;&nbsp;&nbsp;&nbsp;"text": "Reverse charge: Customer to account for VAT to the relevant tax authority."<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
 
-**Output:**
-- **Note:** Reverse charge: Customer to account for VAT to the relevant tax authority. (reverse-charge)
 </Accordion>
+</AccordionGroup>
 
 ## Validation Rules
+
+Validation rules check each struct against a set of assertions and report any
+failures with a unique code and message.
+[Read more about validation](/overview/validation).
 
 <AccordionGroup>
 <Accordion title="tax.Identity">

--- a/regimes/co.mdx
+++ b/regimes/co.mdx
@@ -62,6 +62,10 @@ The types of invoices that can be created with a preceding definition:
 
 ## Validation Rules
 
+Validation rules check each struct against a set of assertions and report any
+failures with a unique code and message.
+[Read more about validation](/overview/validation).
+
 <AccordionGroup>
 <Accordion title="tax.Identity">
 

--- a/regimes/de.mdx
+++ b/regimes/de.mdx
@@ -49,18 +49,24 @@ The types of invoices that can be created with a preceding definition:
 
 ## Scenarios
 
-### bill/invoice
+Scenarios attach notes and extensions to a document when its filters match.
+[Read more about scenarios](/overview/scenarios).
 
-<Accordion title="#reverse-charge">
+<AccordionGroup>
+<Accordion title="bill/invoice">
 
-**Filters:**
-- **Tags:** `reverse-charge`
+| Tags | Categories | Output |
+| --- | --- | --- |
+| `reverse-charge` | `VAT` | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"note": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"cat": "VAT",<br/>&nbsp;&nbsp;&nbsp;&nbsp;"key": "reverse-charge",<br/>&nbsp;&nbsp;&nbsp;&nbsp;"text": "Reverse Charge / Umkehr der Steuerschuld."<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
 
-**Output:**
-- **Note:** Reverse Charge / Umkehr der Steuerschuld. (reverse-charge)
 </Accordion>
+</AccordionGroup>
 
 ## Validation Rules
+
+Validation rules check each struct against a set of assertions and report any
+failures with a unique code and message.
+[Read more about validation](/overview/validation).
 
 <AccordionGroup>
 <Accordion title="bill.Invoice">

--- a/regimes/dk.mdx
+++ b/regimes/dk.mdx
@@ -47,6 +47,10 @@ The types of invoices that can be created with a preceding definition:
 
 ## Validation Rules
 
+Validation rules check each struct against a set of assertions and report any
+failures with a unique code and message.
+[Read more about validation](/overview/validation).
+
 <AccordionGroup>
 <Accordion title="bill.Invoice">
 

--- a/regimes/el.mdx
+++ b/regimes/el.mdx
@@ -61,13 +61,15 @@ Stamp keys from the previous invoice that need to be referenced:
 
 ## Scenarios
 
-### bill/invoice
+Scenarios attach notes and extensions to a document when its filters match.
+[Read more about scenarios](/overview/scenarios).
 
-<Accordion title="#reverse-charge">
+<AccordionGroup>
+<Accordion title="bill/invoice">
 
-**Filters:**
-- **Tags:** `reverse-charge`
+| Tags | Categories | Output |
+| --- | --- | --- |
+| `reverse-charge` | `VAT` | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"note": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"cat": "VAT",<br/>&nbsp;&nbsp;&nbsp;&nbsp;"key": "reverse-charge",<br/>&nbsp;&nbsp;&nbsp;&nbsp;"text": "Reverse Charge / Αντίστροφη φόρτιση"<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
 
-**Output:**
-- **Note:** Reverse Charge / Αντίστροφη φόρτιση (reverse-charge)
 </Accordion>
+</AccordionGroup>

--- a/regimes/es.mdx
+++ b/regimes/es.mdx
@@ -86,135 +86,37 @@ The types of invoices that can be created with a preceding definition:
 
 ## Scenarios
 
-### bill/invoice
+Scenarios attach notes and extensions to a document when its filters match.
+[Read more about scenarios](/overview/scenarios).
 
-<Accordion title="#reverse-charge">
+<AccordionGroup>
+<Accordion title="bill/invoice">
 
-**Filters:**
-- **Tags:** `reverse-charge`
+| Tags | Categories | Output |
+| --- | --- | --- |
+| `reverse-charge` | `VAT` | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"note": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"cat": "VAT",<br/>&nbsp;&nbsp;&nbsp;&nbsp;"key": "reverse-charge",<br/>&nbsp;&nbsp;&nbsp;&nbsp;"text": "Reverse Charge / Inversión del sujeto pasivo."<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
+| `reverse-charge` | `IGIC` | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"note": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"cat": "IGIC",<br/>&nbsp;&nbsp;&nbsp;&nbsp;"key": "reverse-charge",<br/>&nbsp;&nbsp;&nbsp;&nbsp;"text": "Reverse Charge / Inversión del sujeto pasivo."<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
+| `simplified-scheme` | `VAT` | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"note": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"cat": "VAT",<br/>&nbsp;&nbsp;&nbsp;&nbsp;"key": "simplified-scheme",<br/>&nbsp;&nbsp;&nbsp;&nbsp;"text": "Factura expedida por contribuyente en régimen simplificado."<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
+| `self-billed` | - | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"note": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"key": "self-billed",<br/>&nbsp;&nbsp;&nbsp;&nbsp;"text": "Facturación por el destinatario."<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
+| `travel-agency` | `VAT` | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"note": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"cat": "VAT",<br/>&nbsp;&nbsp;&nbsp;&nbsp;"key": "travel-agency",<br/>&nbsp;&nbsp;&nbsp;&nbsp;"text": "Régimen especial de las agencias de viajes."<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
+| `travel-agency` | `IGIC` | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"note": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"cat": "IGIC",<br/>&nbsp;&nbsp;&nbsp;&nbsp;"key": "travel-agency",<br/>&nbsp;&nbsp;&nbsp;&nbsp;"text": "Régimen especial de las agencias de viajes."<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
+| `second-hand-goods` | `VAT` | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"note": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"cat": "VAT",<br/>&nbsp;&nbsp;&nbsp;&nbsp;"key": "second-hand-goods",<br/>&nbsp;&nbsp;&nbsp;&nbsp;"text": "Régimen especial de los bienes usados."<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
+| `second-hand-goods` | `IGIC` | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"note": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"cat": "IGIC",<br/>&nbsp;&nbsp;&nbsp;&nbsp;"key": "second-hand-goods",<br/>&nbsp;&nbsp;&nbsp;&nbsp;"text": "Régimen especial de los bienes usados."<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
+| `art` | `VAT` | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"note": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"cat": "VAT",<br/>&nbsp;&nbsp;&nbsp;&nbsp;"key": "art",<br/>&nbsp;&nbsp;&nbsp;&nbsp;"text": "Régimen especial de los objetos de arte."<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
+| `art` | `IGIC` | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"note": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"cat": "IGIC",<br/>&nbsp;&nbsp;&nbsp;&nbsp;"key": "art",<br/>&nbsp;&nbsp;&nbsp;&nbsp;"text": "Régimen especial de los objetos de arte."<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
+| `antiques` | `VAT` | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"note": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"cat": "VAT",<br/>&nbsp;&nbsp;&nbsp;&nbsp;"key": "antiques",<br/>&nbsp;&nbsp;&nbsp;&nbsp;"text": "Régimen especial de las antigüedades y objetos de colección."<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
+| `antiques` | `IGIC` | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"note": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"cat": "IGIC",<br/>&nbsp;&nbsp;&nbsp;&nbsp;"key": "antiques",<br/>&nbsp;&nbsp;&nbsp;&nbsp;"text": "Régimen especial de las antigüedades y objetos de colección."<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
+| `cash-basis` | `VAT` | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"note": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"cat": "VAT",<br/>&nbsp;&nbsp;&nbsp;&nbsp;"key": "cash-basis",<br/>&nbsp;&nbsp;&nbsp;&nbsp;"text": "Régimen especial del criterio de caja."<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
+| `cash-basis` | `IGIC` | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"note": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"cat": "IGIC",<br/>&nbsp;&nbsp;&nbsp;&nbsp;"key": "cash-basis",<br/>&nbsp;&nbsp;&nbsp;&nbsp;"text": "Régimen especial del criterio de caja."<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
 
-**Output:**
-- **Note:** Reverse Charge / Inversión del sujeto pasivo. (reverse-charge)
 </Accordion>
-
-<Accordion title="#reverse-charge">
-
-**Filters:**
-- **Tags:** `reverse-charge`
-
-**Output:**
-- **Note:** Reverse Charge / Inversión del sujeto pasivo. (reverse-charge)
-</Accordion>
-
-<Accordion title="#simplified-scheme">
-
-**Filters:**
-- **Tags:** `simplified-scheme`
-
-**Output:**
-- **Note:** Factura expedida por contribuyente en régimen simplificado. (simplified-scheme)
-</Accordion>
-
-<Accordion title="#self-billed">
-
-**Filters:**
-- **Tags:** `self-billed`
-
-**Output:**
-- **Note:** Facturación por el destinatario. (self-billed)
-</Accordion>
-
-<Accordion title="#travel-agency">
-
-**Filters:**
-- **Tags:** `travel-agency`
-
-**Output:**
-- **Note:** Régimen especial de las agencias de viajes. (travel-agency)
-</Accordion>
-
-<Accordion title="#travel-agency">
-
-**Filters:**
-- **Tags:** `travel-agency`
-
-**Output:**
-- **Note:** Régimen especial de las agencias de viajes. (travel-agency)
-</Accordion>
-
-<Accordion title="#second-hand-goods">
-
-**Filters:**
-- **Tags:** `second-hand-goods`
-
-**Output:**
-- **Note:** Régimen especial de los bienes usados. (second-hand-goods)
-</Accordion>
-
-<Accordion title="#second-hand-goods">
-
-**Filters:**
-- **Tags:** `second-hand-goods`
-
-**Output:**
-- **Note:** Régimen especial de los bienes usados. (second-hand-goods)
-</Accordion>
-
-<Accordion title="#art">
-
-**Filters:**
-- **Tags:** `art`
-
-**Output:**
-- **Note:** Régimen especial de los objetos de arte. (art)
-</Accordion>
-
-<Accordion title="#art">
-
-**Filters:**
-- **Tags:** `art`
-
-**Output:**
-- **Note:** Régimen especial de los objetos de arte. (art)
-</Accordion>
-
-<Accordion title="#antiques">
-
-**Filters:**
-- **Tags:** `antiques`
-
-**Output:**
-- **Note:** Régimen especial de las antigüedades y objetos de colección. (antiques)
-</Accordion>
-
-<Accordion title="#antiques">
-
-**Filters:**
-- **Tags:** `antiques`
-
-**Output:**
-- **Note:** Régimen especial de las antigüedades y objetos de colección. (antiques)
-</Accordion>
-
-<Accordion title="#cash-basis">
-
-**Filters:**
-- **Tags:** `cash-basis`
-
-**Output:**
-- **Note:** Régimen especial del criterio de caja. (cash-basis)
-</Accordion>
-
-<Accordion title="#cash-basis">
-
-**Filters:**
-- **Tags:** `cash-basis`
-
-**Output:**
-- **Note:** Régimen especial del criterio de caja. (cash-basis)
-</Accordion>
+</AccordionGroup>
 
 ## Validation Rules
+
+Validation rules check each struct against a set of assertions and report any
+failures with a unique code and message.
+[Read more about validation](/overview/validation).
 
 <AccordionGroup>
 <Accordion title="bill.Invoice">

--- a/regimes/fr.mdx
+++ b/regimes/fr.mdx
@@ -56,18 +56,24 @@ The types of invoices that can be created with a preceding definition:
 
 ## Scenarios
 
-### bill/invoice
+Scenarios attach notes and extensions to a document when its filters match.
+[Read more about scenarios](/overview/scenarios).
 
-<Accordion title="#reverse-charge">
+<AccordionGroup>
+<Accordion title="bill/invoice">
 
-**Filters:**
-- **Tags:** `reverse-charge`
+| Tags | Categories | Output |
+| --- | --- | --- |
+| `reverse-charge` | `VAT` | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"note": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"cat": "VAT",<br/>&nbsp;&nbsp;&nbsp;&nbsp;"key": "reverse-charge",<br/>&nbsp;&nbsp;&nbsp;&nbsp;"text": "Reverse Charge / Autoliquidation de la TVA - Article 283-1 du CGI. Le client est redevable de la TVA."<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
 
-**Output:**
-- **Note:** Reverse Charge / Autoliquidation de la TVA - Article 283-1 du CGI. Le client est redevable de la TVA. (reverse-charge)
 </Accordion>
+</AccordionGroup>
 
 ## Validation Rules
+
+Validation rules check each struct against a set of assertions and report any
+failures with a unique code and message.
+[Read more about validation](/overview/validation).
 
 <AccordionGroup>
 <Accordion title="bill.Invoice">

--- a/regimes/gb.mdx
+++ b/regimes/gb.mdx
@@ -50,18 +50,24 @@ The types of invoices that can be created with a preceding definition:
 
 ## Scenarios
 
-### bill/invoice
+Scenarios attach notes and extensions to a document when its filters match.
+[Read more about scenarios](/overview/scenarios).
 
-<Accordion title="#reverse-charge">
+<AccordionGroup>
+<Accordion title="bill/invoice">
 
-**Filters:**
-- **Tags:** `reverse-charge`
+| Tags | Categories | Output |
+| --- | --- | --- |
+| `reverse-charge` | `VAT` | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"note": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"cat": "VAT",<br/>&nbsp;&nbsp;&nbsp;&nbsp;"key": "reverse-charge",<br/>&nbsp;&nbsp;&nbsp;&nbsp;"text": "Reverse charge: Customer to account for VAT to the relevant tax authority."<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
 
-**Output:**
-- **Note:** Reverse charge: Customer to account for VAT to the relevant tax authority. (reverse-charge)
 </Accordion>
+</AccordionGroup>
 
 ## Validation Rules
+
+Validation rules check each struct against a set of assertions and report any
+failures with a unique code and message.
+[Read more about validation](/overview/validation).
 
 <AccordionGroup>
 <Accordion title="tax.Identity">

--- a/regimes/ie.mdx
+++ b/regimes/ie.mdx
@@ -40,18 +40,24 @@ PEPPOL is supported for B2G transactions.
 
 ## Scenarios
 
-### bill/invoice
+Scenarios attach notes and extensions to a document when its filters match.
+[Read more about scenarios](/overview/scenarios).
 
-<Accordion title="#reverse-charge">
+<AccordionGroup>
+<Accordion title="bill/invoice">
 
-**Filters:**
-- **Tags:** `reverse-charge`
+| Tags | Categories | Output |
+| --- | --- | --- |
+| `reverse-charge` | `VAT` | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"note": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"cat": "VAT",<br/>&nbsp;&nbsp;&nbsp;&nbsp;"key": "reverse-charge",<br/>&nbsp;&nbsp;&nbsp;&nbsp;"text": "Reverse charge: Customer to account for VAT to the relevant tax authority."<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
 
-**Output:**
-- **Note:** Reverse charge: Customer to account for VAT to the relevant tax authority. (reverse-charge)
 </Accordion>
+</AccordionGroup>
 
 ## Validation Rules
+
+Validation rules check each struct against a set of assertions and report any
+failures with a unique code and message.
+[Read more about validation](/overview/validation).
 
 <AccordionGroup>
 <Accordion title="tax.Identity">

--- a/regimes/in.mdx
+++ b/regimes/in.mdx
@@ -52,27 +52,25 @@ The types of invoices that can be created with a preceding definition:
 
 ## Scenarios
 
-### bill/invoice
+Scenarios attach notes and extensions to a document when its filters match.
+[Read more about scenarios](/overview/scenarios).
 
-<Accordion title="#reverse-charge">
+<AccordionGroup>
+<Accordion title="bill/invoice">
 
-**Filters:**
-- **Tags:** `reverse-charge`
+| Tags | Output |
+| --- | --- |
+| `reverse-charge` | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"note": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"key": "reverse-charge",<br/>&nbsp;&nbsp;&nbsp;&nbsp;"text": "Reverse Charge"<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
+| `simplified` | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"note": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"key": "simplified",<br/>&nbsp;&nbsp;&nbsp;&nbsp;"text": "Simplified Tax Invoice"<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
 
-**Output:**
-- **Note:** Reverse Charge (reverse-charge)
 </Accordion>
-
-<Accordion title="#simplified">
-
-**Filters:**
-- **Tags:** `simplified`
-
-**Output:**
-- **Note:** Simplified Tax Invoice (simplified)
-</Accordion>
+</AccordionGroup>
 
 ## Validation Rules
+
+Validation rules check each struct against a set of assertions and report any
+failures with a unique code and message.
+[Read more about validation](/overview/validation).
 
 <AccordionGroup>
 <Accordion title="org.Identity">

--- a/regimes/it.mdx
+++ b/regimes/it.mdx
@@ -64,18 +64,24 @@ The types of invoices that can be created with a preceding definition:
 
 ## Scenarios
 
-### bill/invoice
+Scenarios attach notes and extensions to a document when its filters match.
+[Read more about scenarios](/overview/scenarios).
 
-<Accordion title="#reverse-charge">
+<AccordionGroup>
+<Accordion title="bill/invoice">
 
-**Filters:**
-- **Tags:** `reverse-charge`
+| Tags | Categories | Output |
+| --- | --- | --- |
+| `reverse-charge` | `VAT` | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"note": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"cat": "VAT",<br/>&nbsp;&nbsp;&nbsp;&nbsp;"key": "reverse-charge",<br/>&nbsp;&nbsp;&nbsp;&nbsp;"text": "Reverse Charge / Inversione del soggetto passivo"<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
 
-**Output:**
-- **Note:** Reverse Charge / Inversione del soggetto passivo (reverse-charge)
 </Accordion>
+</AccordionGroup>
 
 ## Validation Rules
+
+Validation rules check each struct against a set of assertions and report any
+failures with a unique code and message.
+[Read more about validation](/overview/validation).
 
 <AccordionGroup>
 <Accordion title="tax.Identity">

--- a/regimes/mx.mdx
+++ b/regimes/mx.mdx
@@ -65,6 +65,10 @@ Stamp keys from the previous invoice that need to be referenced:
 
 ## Validation Rules
 
+Validation rules check each struct against a set of assertions and report any
+failures with a unique code and message.
+[Read more about validation](/overview/validation).
+
 <AccordionGroup>
 <Accordion title="tax.Identity">
 

--- a/regimes/nl.mdx
+++ b/regimes/nl.mdx
@@ -51,18 +51,24 @@ The types of invoices that can be created with a preceding definition:
 
 ## Scenarios
 
-### bill/invoice
+Scenarios attach notes and extensions to a document when its filters match.
+[Read more about scenarios](/overview/scenarios).
 
-<Accordion title="#reverse-charge">
+<AccordionGroup>
+<Accordion title="bill/invoice">
 
-**Filters:**
-- **Tags:** `reverse-charge`
+| Tags | Categories | Output |
+| --- | --- | --- |
+| `reverse-charge` | `VAT` | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"note": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"cat": "VAT",<br/>&nbsp;&nbsp;&nbsp;&nbsp;"key": "reverse-charge",<br/>&nbsp;&nbsp;&nbsp;&nbsp;"text": "Reverse charge: Customer to account for VAT to the relevant tax authority."<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
 
-**Output:**
-- **Note:** Reverse charge: Customer to account for VAT to the relevant tax authority. (reverse-charge)
 </Accordion>
+</AccordionGroup>
 
 ## Validation Rules
+
+Validation rules check each struct against a set of assertions and report any
+failures with a unique code and message.
+[Read more about validation](/overview/validation).
 
 <AccordionGroup>
 <Accordion title="bill.Invoice">

--- a/regimes/pl.mdx
+++ b/regimes/pl.mdx
@@ -41,6 +41,10 @@ E-invoicing via PEPPOL is used for cross-border and B2G transactions.
 
 ## Validation Rules
 
+Validation rules check each struct against a set of assertions and report any
+failures with a unique code and message.
+[Read more about validation](/overview/validation).
+
 <AccordionGroup>
 <Accordion title="bill.Invoice">
 

--- a/regimes/pt.mdx
+++ b/regimes/pt.mdx
@@ -357,6 +357,10 @@ For example:
 
 ## Validation Rules
 
+Validation rules check each struct against a set of assertions and report any
+failures with a unique code and message.
+[Read more about validation](/overview/validation).
+
 <AccordionGroup>
 <Accordion title="bill.Invoice">
 

--- a/regimes/se.mdx
+++ b/regimes/se.mdx
@@ -47,18 +47,24 @@ for transactions up to 4000 SEK.
 
 ## Scenarios
 
-### bill/invoice
+Scenarios attach notes and extensions to a document when its filters match.
+[Read more about scenarios](/overview/scenarios).
 
-<Accordion title="#reverse-charge">
+<AccordionGroup>
+<Accordion title="bill/invoice">
 
-**Filters:**
-- **Tags:** `reverse-charge`
+| Tags | Categories | Output |
+| --- | --- | --- |
+| `reverse-charge` | `VAT` | <code class="code-block">&#123;<br/>&nbsp;&nbsp;"note": &#123;<br/>&nbsp;&nbsp;&nbsp;&nbsp;"cat": "VAT",<br/>&nbsp;&nbsp;&nbsp;&nbsp;"key": "reverse-charge",<br/>&nbsp;&nbsp;&nbsp;&nbsp;"text": "Reverse charge: Customer to account for VAT to the relevant tax authority."<br/>&nbsp;&nbsp;&#125;<br/>&#125;</code> |
 
-**Output:**
-- **Note:** Reverse charge: Customer to account for VAT to the relevant tax authority. (reverse-charge)
 </Accordion>
+</AccordionGroup>
 
 ## Validation Rules
+
+Validation rules check each struct against a set of assertions and report any
+failures with a unique code and message.
+[Read more about validation](/overview/validation).
 
 <AccordionGroup>
 <Accordion title="tax.Identity">

--- a/regimes/sg.mdx
+++ b/regimes/sg.mdx
@@ -50,6 +50,10 @@ The types of invoices that can be created with a preceding definition:
 
 ## Validation Rules
 
+Validation rules check each struct against a set of assertions and report any
+failures with a unique code and message.
+[Read more about validation](/overview/validation).
+
 <AccordionGroup>
 <Accordion title="bill.Invoice">
 

--- a/style.css
+++ b/style.css
@@ -6,6 +6,11 @@
   margin: 0 0 0.4em -0.5em;
 }
 
+.prose table tr td code.code-block {
+  display: block;
+}
+
+
 /* repurpose bullets in test lists to indicate required vs conditional */
 .prose table tr td ul.gobl-test li {
   padding-left: 1em !important;


### PR DESCRIPTION
Before:

<img width="948" height="890" alt="image" src="https://github.com/user-attachments/assets/f56bc864-3a76-4227-a571-24601a6e3aac" />

After:

<img width="762" height="865" alt="image" src="https://github.com/user-attachments/assets/ca4260f4-3bf8-41dd-a1da-d4508a887a8f" />

## Summary

- Investigation kicked off because Spain's `regimes/es.mdx` rendered the **reverse-charge** scenario (and several others) twice. Root cause: GOBL declares distinct VAT- and IGIC-scoped scenarios, but the generator template never surfaced the `Categories` filter that distinguished them, so the two collapsed visually.
- Reworked the **Scenarios** section in every regime/addon page. Each schema now sits inside an `<Accordion>` (mirroring **Validation Rules**) and is rendered as a single table. Columns are computed per table from the filters that are actually populated — empty filter columns are dropped so each country/standard shows only the dimensions that matter to it.
- The **Output** column shows the JSON GOBL emits (`note`/`codes`/`ext`) using the real wire shape — including `Note.Category`, `Note.Key`, etc. — instead of a flattened summary. Indented JSON is rendered via `<code class="code-block">` with `<br/>` + `&nbsp;` so it lays out neatly inside table cells. The matching display rule lives in `style.css`.
- Custom `Filter` functions can't be introspected, but `tax.Scenario` already exposes `Name` / `Desc` (i18n strings) for documentation. The new `customFilterLabel` helper renders `Desc` when set, then `Name`, and otherwise emits a bare `[custom](URL)` link to the function's source on GitHub at the gobl version pinned in `go.mod` — using `runtime.FuncForPC` to resolve the file:line.
- Added an overview article at `overview/scenarios.mdx` explaining how scenarios match documents, what each filter checks, and where outputs land (notes → `tax.notes`, ext → `tax.ext`, codes → summary). Both the Scenarios and Validation Rules section headers in regime/addon pages now link to their respective overview articles instead of repeating the explanation inline.

## Test plan

- [x] `go build ./cmd/generate && ./generate` runs cleanly.
- [x] `mint dev` — visit `regimes/es` and confirm the two reverse-charge rows are now disambiguated by the `Categories` column.
- [x] Visit `addons/es-verifactu-v1` and confirm the `Categories` column is **hidden** (none of its scenarios use it).
- [x] Visit `addons/pt-saft-v1` and `addons/mx-cfdi-v4`; the custom-filter rows render as a `custom` link to GitHub at `v0.401.0` (or whatever version `go.mod` pins).
- [x] Visit `overview/scenarios` from the sidebar (Overview group).
- [x] Confirm the **Output** column is monospace-styled with each line on its own row (CSS `.code-block { display: block }` rule).

🤖 Generated with [Claude Code](https://claude.com/claude-code)